### PR TITLE
CMakeLists.txt: Add debug symbols to release build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 2.8)
 set(CMAKE_DISABLE_SOURCE_CHANGES ON)
 set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
 
+set(CMAKE_BUILD_TYPE RelWithDebInfo)
+
 project(tfs)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")


### PR DESCRIPTION
The default currently seems to be a `Release` build without debugging symbols. While using a `Debug` build makes code easier to follow in a debugger, it can have a considerable effect on performance, so for now, let's keep using a `Release` build, but without stripping the debug symbols. This makes the resulting executable larger, but shouldn't have a runtime cost.

Refer to https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html for more information.